### PR TITLE
add htstream to applications

### DIFF
--- a/src/knet.app.src
+++ b/src/knet.app.src
@@ -9,6 +9,7 @@
          stdlib,
          lager,
          feta,
+         htstream,
          pipe,
          datum,
          pns 


### PR DESCRIPTION
Rationale:
knet uses functions from `pstream` module in `knet_{tcp,udp,ssl}`.

Module `pstream` is provided by the library `htstream` (library since
there is no supervision tree asssosciated with it - only modules
providing functions). Libraries must also be included in `applications`.

When building a release, erlang tooling conventions require that
all runtime dependencies be listed in either `applications` or
`included_applications`. `included_applications` is a very special
case, usually dependncies go into `applications`.
(R17+ introduces `runtime_dependencies` for additional metadata but
let's ignore that for now.)

In absence of this, applications depending on knet will fail to run
when built into a release unless `htstream` is either added manually
or another dependency luckily includes it.